### PR TITLE
Fix typo in performance section header

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Running ReactMicroBenchmark with specific number of executions and number of com
 $ java ReactMicroBenchmark 100 10
 ```
 
-## Perfomance Results
+## Performance Results
 Performance comparing Nashorn with node.js. Nashorn takes a little longer to warm-up but after 10000 iterations it matches node.js performance.
 
 ### Java 8 - Nashorn


### PR DESCRIPTION
## Summary
- correct the spelling of the "Performance Results" section header in README.md

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b92265b44832fa3b90b8e294a55ce)