### PR TITLE
Export renderServer and add test

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ Run #1000: 0.4652369999999948 ms
 ...
 Run #10000: 0.4628829999999766 ms
 ```
+
+### Running the renderServer test
+```
+$ node test/renderServer.test.js
+```
 ### Machine Info
 These tests were run using a MacBook Pro (Retina, 15-inch, Mid 2014) with 2.8 GHz Intel Core i7 processor and 16 GB 1600 MHz DDR3 of memory.
 

--- a/ReactMicroBenchmark.js
+++ b/ReactMicroBenchmark.js
@@ -107,18 +107,24 @@ var renderServer = function (comments) {
     );
 };
 
-log = console.log.bind(console);
-timestamp = function() { return process.hrtime()[1] / 1e6; };
+module.exports = {
+    renderServer: renderServer
+};
 
-var comments = [];
-var NUM_COMMENTS = 10;
-for (var i = 0; i < NUM_COMMENTS; ++i) {
-    comments.push({author:"Name "+i, text:"This is comment #"+i+"."});
-}
-for (i = 0; i < 10000; ++i) {
-    var start, stop;
-    start = timestamp();
-    renderServer(comments);
-    stop = timestamp();
-    log('Run #' + (i + 1) + ':', (stop - start), 'ms');
+var log = console.log.bind(console);
+var timestamp = function() { return process.hrtime()[1] / 1e6; };
+
+if (require.main === module) {
+    var comments = [];
+    var NUM_COMMENTS = 10;
+    for (var i = 0; i < NUM_COMMENTS; ++i) {
+        comments.push({author:"Name "+i, text:"This is comment #"+i+"."});
+    }
+    for (i = 0; i < 10000; ++i) {
+        var start, stop;
+        start = timestamp();
+        renderServer(comments);
+        stop = timestamp();
+        log('Run #' + (i + 1) + ':', (stop - start), 'ms');
+    }
 }

--- a/test/renderServer.test.js
+++ b/test/renderServer.test.js
@@ -1,0 +1,13 @@
+const assert = require('assert');
+const { renderServer } = require('../ReactMicroBenchmark');
+
+const result = renderServer([
+    { author: 'Alice', text: 'Hello' },
+    { author: 'Bob', text: 'Hi there' }
+]);
+
+assert.strictEqual(typeof result, 'string', 'renderServer should return a string');
+assert.ok(result.length > 0, 'renderServer result should not be empty');
+assert.ok(result.includes('<div'), 'rendered markup should contain a <div> element');
+
+console.log('renderServer test passed');


### PR DESCRIPTION
## Summary
- export the `renderServer` helper so it can be required by other modules and only run the benchmark loop when the script is executed directly
- add a small test that exercises `renderServer` and ensure it produces HTML markup
- document how to run the new test in the README

## Testing
- node test/renderServer.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b9238b820832f9ea6f01224a86c48)